### PR TITLE
Add cookie-free RSS viewer

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,35 +2,68 @@
 <html lang="nl">
 <head>
   <meta charset="utf-8">
-  <title>FeedWind – full‑screen widget</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
-
+  <title>Nieuws zonder cookies</title>
   <style>
-    /* de body en html moeten zelf 100 % hoog zijn */
-    html, body { height: 200; margin: 0; }
-
-    /* wrapper die de widget de volledige ruimte geeft */
-    #fw-wrapper { height: 500; }
-
-    /* overschrijf de vaste px‑hoogte die FeedWind meegeeft */
-    iframe[src*="feed.mikle.com"] {
-      width: 80 !important;
-      height: 500 !important;
-      border: 0;
-      display: block;        /* haalt ongewenste witruimte weg */
+    html, body {
+      height: 100%;
+      margin: 0;
+      background: #000;
+      color: #fff;
+      font-family: Arial, Helvetica, sans-serif;
+      font-size: 2.5vh;
+      line-height: 1.4;
+    }
+    #feed {
+      padding: 2rem;
+      display: flex;
+      flex-direction: column;
+      gap: 2rem;
+    }
+    article {
+      background: #111;
+      padding: 1rem;
+      border-radius: 0.5rem;
+    }
+    h2 {
+      margin: 0 0 0.5rem 0;
+      font-size: 3vh;
+    }
+    a {
+      color: #ffd700;
+      text-decoration: none;
+    }
+    a:hover {
+      text-decoration: underline;
     }
   </style>
 </head>
-
 <body>
-  <div id="fw-wrapper">
-    <!-- start feedwind code -->
-    <script
-      src="https://feed.mikle.com/js/fw-loader.js"
-      preloader-text="Loading"
-      data-fw-param="172345/">
-    </script>
-    <!-- end feedwind code -->
-  </div>
+  <div id="feed">Nieuws wordt geladen…</div>
+  <script>
+    async function loadFeed() {
+      const feedUrl = encodeURIComponent('https://rss.nytimes.com/services/xml/rss/nyt/HomePage.xml');
+      try {
+        const response = await fetch('https://api.allorigins.win/raw?url=' + feedUrl);
+        const text = await response.text();
+        const doc = new DOMParser().parseFromString(text, 'application/xml');
+        const items = doc.querySelectorAll('item');
+        const container = document.getElementById('feed');
+        container.innerHTML = '';
+        items.forEach(item => {
+          const title = item.querySelector('title')?.textContent || 'Geen titel';
+          const link = item.querySelector('link')?.textContent || '#';
+          const description = item.querySelector('description')?.textContent || '';
+          const article = document.createElement('article');
+          article.innerHTML = `<h2><a href="${link}" target="_blank" rel="noopener">${title}</a></h2><p>${description}</p>`;
+          container.appendChild(article);
+        });
+      } catch (err) {
+        document.getElementById('feed').textContent = 'Fout bij het laden van de feed.';
+        console.error(err);
+      }
+    }
+    window.addEventListener('load', loadFeed);
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace FeedWind widget with simple script that fetches RSS
- style page for high-resolution fullscreen display

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684166e3606c83298794f81abe307182